### PR TITLE
Run Via tests against Safari and Edge

### DIFF
--- a/smokey/features/via.feature
+++ b/smokey/features/via.feature
@@ -4,6 +4,8 @@ Feature: Via proxy
       |browser|
       |Sauce-Firefox|
       |Sauce-Chrome|
+      |Sauce-Safari|
+      |Sauce-Edge|
     When I visit "http://example.com" with Via
     Then I should see the Hypothesis sidebar
     And I should see at least 2 annotations


### PR DESCRIPTION
Now that Via's issues with Safari and Edge have been
fixed, include these browsers in smoke tests.