### PR TITLE
Smokey reliability improvements

### DIFF
--- a/checkrealtime/Makefile
+++ b/checkrealtime/Makefile
@@ -1,12 +1,6 @@
 GOHOSTOS := $(shell go env GOHOSTOS)
 GOHOSTARCH := $(shell go env GOHOSTARCH)
-
-# If we're building on an OS or architecture other than linux-amd64, the target
-# will be created with the -linux-amd64 suffix, so we need to account for that.
-GOTARGETSUFFIX :=
-ifneq ($(GOHOSTOS)-$(GOHOSTARCH),linux-amd64)
-	GOTARGETSUFFIX := -linux-amd64
-endif
+GOTARGETSUFFIX := -linux-amd64
 
 default: run
 

--- a/smokey/features/environment.py
+++ b/smokey/features/environment.py
@@ -49,8 +49,10 @@ def before_all(context):
 def autoretry_scenario(scenario_or_outline):
     """
     Monkey-patches Scenario.run() to auto-retry a scenario that fails.
-    This has been proposed upstream but rejected on reasonable grounds
-    - see https://github.com/behave/behave/pull/328
+
+    This has been accepted upstream for Behave 1.2.6 as
+    behave.contrib.scenario_autoretry (see
+    https://github.com/behave/behave/commit/ca7259b7)
     """
     def run_scenario(original_run, *args, **kwargs):
         max_attempts = 3

--- a/smokey/features/steps/client.py
+++ b/smokey/features/steps/client.py
@@ -27,11 +27,9 @@ def wait_for_hypothesis_sidebar(context):
 def wait_for_annotations(context, count):
     count = int(count)
     driver = context.browser.driver
-    saw_highlight = EC.presence_of_element_located((By.CLASS_NAME,
-                                                    H_HIGHLIGHT_CLASS))
-    WebDriverWait(driver, 30).until(saw_highlight)
 
-    highlights = driver.find_elements_by_class_name(H_HIGHLIGHT_CLASS)
+    def found_highlights(driver):
+        highlights = driver.find_elements_by_class_name(H_HIGHLIGHT_CLASS)
+        return len(highlights) >= count
 
-    if len(highlights) < count:
-        raise Exception('Found only {} annotations'.format(len(highlights)))
+    WebDriverWait(driver, 15).until(found_highlights)

--- a/smokey/features/steps/webdriver.py
+++ b/smokey/features/steps/webdriver.py
@@ -29,6 +29,7 @@ class Browser(object):
 
     def __init__(self, browser):
         self.name = browser
+        self.driver = None
 
     def start(self, context):
         """
@@ -81,7 +82,8 @@ class Browser(object):
 
     def close(self):
         """Shut down the WebDriver instance."""
-        self.driver.quit()
+        if self.driver:
+            self.driver.quit()
 
     def _start_sauce_browser(self, context):
         username = context.config.userdata['sauce_username']

--- a/smokey/features/via.feature
+++ b/smokey/features/via.feature
@@ -1,5 +1,5 @@
 Feature: Via proxy
-  @sauce
+  @sauce @autoretry
   Scenario Outline: Visiting a URL through Via
     Given I am using supported browser "<browser>"
     When I visit "http://example.com" with Via

--- a/tools/parse-log.py
+++ b/tools/parse-log.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import argparse
+import re
+
+
+def extract_python_exceptions(log_file):
+    """
+       Searches a log file for references to Python exceptions
+       and returns an array of lines describing the type of
+       exception that occurred.
+    """
+    for line in log_file:
+        match = re.match('^(\s+)Traceback', line)
+        if match:
+            indent = len(match.group(1))
+            for line in log_file:
+                line_indent = len(re.match('^\s*', line).group(0))
+                if line_indent == indent:
+                    yield line.strip()
+                    break
+
+
+def main():
+    parser = argparse.ArgumentParser(description=
+"""Extracts a list of exceptions from Smokey logs.
+
+Given a log file from Smokey, this script parses
+out and prints details of exceptions that occurred.
+""")
+    parser.add_argument('log_file', help="The Smokey log file")
+    args = parser.parse_args()
+
+    for exception in extract_python_exceptions(open(args.log_file)):
+        print('{}'.format(exception))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit adds an auto-retry mechanism to scenarios and enables it for the tests involving Sauce Labs browsers which are suffering from intermittent connectivity issues.

Whereas the retry mechanism for the API can retry at the step level, for these tests I thought it better to retry the whole scenario if there is a failure, since individual steps assume the presence of a working connection to a browser which may have been lost if the browser crashed etc. Behave lacks a built-in mechanism for retrying scenarios, so this PR implements one by monkey-patching `behave.model.Scenario.run` on scenarios or outlines which have been specifically tagged with `@autoretry`.

This also addresses an incorrect assumption in one of the steps that once at least one highlight was anchored on the page, all of them were. This could result in failures if WebDriver counted the number of highlights whilst they were still being anchored.