### PR TITLE
Fix a deadlock by draining the WS messages queue

### DIFF
--- a/smokey/features/steps/websocket.py
+++ b/smokey/features/steps/websocket.py
@@ -127,10 +127,24 @@ def listen_for_notifications(context):
     context.websocket_messages = messages
 
     # When we teardown the test context, we set the "close" event, which will
-    # trigger clean websocket shutdown, and then wait for the process to
-    # complete.
+    # trigger clean websocket shutdown, drain the queue, and then wait for the
+    # process to complete.
+    #
+    # We have to drain the messages queue because if the underlying pipe
+    # buffer is full (because, for example, we've received a lot of annotation
+    # notifications after the one we were looking for) then the queue writer
+    # process will block, and `websocket.join()` will deadlock. See the Python
+    # docs for details:
+    #
+    #     https://docs.python.org/3/library/multiprocessing.html#pipes-and-queues
+    #
     def cleanup():
         close.set()
+        while True:
+            try:
+                messages.get_nowait()
+            except queue.Empty:
+                break
         websocket.join()
     context.teardown.append(cleanup)
 

--- a/smokey/features/steps/websocket.py
+++ b/smokey/features/steps/websocket.py
@@ -38,15 +38,16 @@ async def enqueue_websocket_messages(endpoint,
     ready.set()
 
     while True:
+        if close.is_set():
+            queue.close()
+            break
+
         done, pending = await asyncio.wait(pending, timeout=0.1)
 
         if done:
             for msg in done:
                 queue.put_nowait(msg.result())
             pending.add(websocket.recv())
-
-        if close.is_set():
-            break
 
     for msg in pending:
         msg.cancel()


### PR DESCRIPTION
Every once in a while, Smokey would fail to exit cleanly, with no problems reported to the logs. Eventually, I straced the "stuck" processing and found the following:

    ubuntu@mon:~$ sudo strace -p 24713
    Process 24713 attached
    write(6, "\0\0\7t\200\3Xj\7\0\0{\"type\": \"annotation-"..., 1912^CProcess 24713 detached

The latter visible part of the blocked `write(2)` call here is recognisable as the JSON sent down the websocket to notify of an annotation event. FD 6 for this process was a pipe:

    ubuntu@mon:~$ sudo ls -dl /proc/24713/fd/6
    l-wx------ 1 libuuid libuuid 64 Feb 18 12:35 /proc/24713/fd/6 -> pipe:[4553700]

Thinking about this for a while, it became apparent that the most likely scenario was that the blocked write call corresponded to a `put()` method call on a `multiprocessing.Queue` object. A minimal reproduction[1] demonstrates that an apparently non-blocking queue write can block if the underlying pipe is full.

[1]: https://gist.github.com/b6f9a6c5196a06cc3c67a367458506ab

So, the fix is (hopefully) straightforward -- ensure that the queue is drained before attempting to join the process using it.

The second commit here reorders operations in the inner loop of the queue writer process so that by the time queue draining starts, we can guarantee that no more messages will be written to the queue, thus avoiding a possible race condition.