### PR TITLE
Add a 4 minute timeout when running tests

### DIFF
--- a/smokey/Dockerfile
+++ b/smokey/Dockerfile
@@ -27,5 +27,8 @@ USER smokey
 # Set the Python IO encoding to UTF-8.
 ENV PYTHONIOENCODING utf_8
 
-# Default command: run the tests.
-CMD ["/usr/bin/behave"]
+# Run tests with a timeout.
+#
+# Note use of 'shell' rather than 'exec' syntax for CMD, otherwise the timeout
+# is not respected.
+CMD timeout -t 240 behave

--- a/smokey/Dockerfile
+++ b/smokey/Dockerfile
@@ -10,6 +10,11 @@ WORKDIR /var/lib/smokey
 
 # Install python dependencies.
 COPY requirements.txt ./
+
+# Upgrade setuptools to work around an issue during installation of the 'six'
+# indirect dependency. See https://github.com/pypa/setuptools/issues/951
+RUN pip install --no-cache-dir -U setuptools
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the test files.


### PR DESCRIPTION
On two occasions in the past two weeks the Smokey tests have hung for many hours when running on the monitoring server. This results in a ton of email spam to the SR list when every 5 minutes a cron job tries to start a new Smokey task and the previous one is still running.

I haven't dug into exactly what happened when the hang occurred, but since the tests involve automating browsers via Sauce labs and fetching external URLs via HTTP, there is a long tail of possible ways this could happen.

This PR adds a 4 minute timeout to the behave test suite using the `timeout` command. The tests typically take about 60s to run on my machine so this should be ample.

Additionally I encountered an issue where the container failed to build on my system, which is fixed by a setuptools update in the first commit.